### PR TITLE
Removed replacement of "=" symbol in URL

### DIFF
--- a/scripts/civitai-api.py
+++ b/scripts/civitai-api.py
@@ -373,7 +373,7 @@ def save_image_files(preview_image_html, model_filename, list_models, content_ty
 
     for i, img_url in enumerate(img_urls):
         filename = f'{name}_{i}.png'
-        img_url = img_url.replace("https", "http").replace("=","%3D")
+        img_url = img_url.replace("https", "http")
 
         print(img_url, filename)
         try:


### PR DESCRIPTION
Preview Images didn't load because the original URL has the "=" symbol in it. Replacing it with "%3D" causes the images to not load correctly and saves them as 1kb corrupted image files